### PR TITLE
Paste handler

### DIFF
--- a/src/richMode/paste.js
+++ b/src/richMode/paste.js
@@ -1,0 +1,120 @@
+'use strict';
+
+function Paste (Compose) {
+  var debug = Compose.require('debug')('compose:paste'),
+      Selection = Compose.require('selection'),
+      sanitize = Compose.require('sanitize'),
+      Delta = Compose.require('delta'),
+      View = Compose.require('view'),
+      startSpace = /^[ \u00A0\u200A]/,
+      endSpace = /[ \u00A0\u200A]$/,
+      nbsp = '\u00A0'
+
+  /**
+   * join(first, second) joins two paragraphs, being mindful of spaces
+   * and whatnot.
+   *
+   * @param {Serialize} first
+   * @param {Serialize} second
+   * @return {Serialize}
+   */
+  function join (first, second) {
+    var result
+
+    if (startSpace.test(second.text) && endSpace.test(first.text))
+      second = second.substr(1)
+    if (second.text === '\n')
+      second = second.substr(1)
+
+    first = first.replace(endSpace, ' ')
+    second = second.replace(startSpace, ' ')
+
+    result = first.append(second)
+    if (result[0] === ' ')
+      result = result.replace(startSpace, nbsp)
+    if (result.text[result.length - 1] === ' ')
+      result = result.replace(endSpace, nbsp)
+
+    return result
+  }
+
+  Compose.on('paste', function onPaste (e) {
+    var sel = Selection.get(),
+        extracted,
+        paragraph,
+        startPair,
+        endPair,
+        types,
+        start,
+        type,
+        data,
+        len,
+        end,
+        i
+
+    e.preventDefault()
+
+    types = e.clipboardData.types
+    debug('Available types: %o', types)
+
+    if (types.indexOf('text/html') >= 0)
+      type = 'text/html'
+    else if (types.indexOf('text/plain') >= 0)
+      type = 'text/plain'
+    else
+      return debug('No usable type.')
+
+    data = e.clipboardData.getData(type)
+    debug('Using data “%s”', data)
+
+    if (type === 'text/plain')
+      extracted = sanitize.text(data).paragraphs
+    else
+      extracted = sanitize(data).paragraphs
+
+    debug('Extracted %d paragraph(s): %o', extracted.length, extracted)
+
+    startPair = sel.isBackwards() ? sel.end : sel.start
+    endPair = sel.isBackwards() ? sel.start : sel.end
+
+    start = View.paragraphs[startPair[0]].substr(0, startPair[1])
+    end = View.paragraphs[endPair[0]].substr(endPair[1])
+
+    if (end.text === '\n')
+      end = end.substr(1)
+
+    for (i = startPair[0] + 1; i <= endPair[0]; i += 1) {
+      if (View.isSectionStart(startPair[0] + i))
+        View.render(new Delta('sectionDelete', startPair[0] + 1))
+
+      View.render(new Delta('paragraphDelete', startPair[0] + 1))
+    }
+
+    for (i = 0; i < extracted.length; i += 1) {
+      paragraph = extracted[i]
+
+      if (i === 0 && start.length)
+        paragraph = join(start, paragraph)
+
+      if (i === extracted.length - 1) {
+        len = paragraph.length
+        paragraph = join(paragraph, end)
+      }
+
+      // This shouldn’t happen, at least in theory.
+      if (!paragraph.text)
+        paragraph.text = '\n'
+
+      if (i === 0)
+        View.render(new Delta('paragraphUpdate', startPair[0], paragraph))
+      else
+        View.render(new Delta('paragraphInsert', startPair[0] + i, paragraph))
+    }
+
+    Compose.once('render', function postPaste () {
+      Selection.set(new Selection([startPair[0] + extracted.length - 1, len]))
+    })
+  })
+}
+
+module.exports = Paste

--- a/src/richMode/richMode.js
+++ b/src/richMode/richMode.js
@@ -13,6 +13,7 @@ var getChildren = require('./getChildren'),
     ViewPlugin = require('./view'),
     Setup = require('./setup'),
     Enter = require('./enterKey'),
+    Paste = require('./paste'),
     Cut = require('./cut')
 
 function RichMode (Compose) {
@@ -40,6 +41,7 @@ function RichMode (Compose) {
   Compose.use(Enter)
   Compose.use(Backspace)
   Compose.use(Cut)
+  Compose.use(Paste)
   Compose.use(Spacebar)
   Compose.use(SmartText)
 

--- a/test/functional/paste.spec.js
+++ b/test/functional/paste.spec.js
@@ -1,0 +1,511 @@
+/* global before, describe, it, beforeEach */
+'use strict';
+
+var chai = require('chai'),
+    utils = require('./utils'),
+    expect = chai.expect,
+    browser
+
+utils.chai(chai)
+
+before(function () {
+  browser = utils.browser
+})
+
+describe('Pasting', function () {
+
+  describe('text should', function () {
+    beforeEach(function () {
+      return browser.get(utils.url())
+    })
+
+    it('insert the pasted text', function () {
+      return utils
+        .init('<p>OneThree</p>', {
+          start: [0, 3]
+        })
+        .paste('text/plain', 'Two')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'OneTwoThree'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 6],
+            end: [0, 6]
+          })
+        })
+    })
+
+    it('remove selected text', function () {
+      return utils
+        .init('<p>ABC</p>', {
+          start: [0, 2],
+          end: [0, 1]
+        })
+        .paste('text/plain', 'X')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'AXC'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 2],
+            end: [0, 2]
+          })
+        })
+    })
+
+    it('deal with spaces', function () {
+      return utils
+        .init('<p>One Two Three</p>', {
+          start: [0, 4],
+          end: [0, 7]
+        })
+        .paste('text/plain', '\u00A0X\u00A0') // Non-breaking spaces
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'One X Three'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 6],
+            end: [0, 6]
+          })
+        })
+    })
+
+    it('remove trailing newlines', function () {
+      return utils
+        .init('<p><br></p>', {
+          start: [0, 0]
+        })
+        .paste('text/plain', 'One')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'One'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 3],
+            end: [0, 3]
+          })
+        })
+    })
+
+    it('split double newlines into multiple paragraphs', function () {
+      return utils
+        .init('<p><br></p>', {
+          start: [0, 0]
+        })
+        .paste('text/plain', 'One\n\nTwo')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'One'
+            }, {
+              name: 'p',
+              html: 'Two'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [1, 3],
+            end: [1, 3]
+          })
+        })
+    })
+
+    it('remove excessive whitespace', function () {
+      return utils
+        .init('<p><br></p>', {
+          start: [0, 0]
+        })
+        .paste('text/plain', 'One   Two')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'One Two'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 7],
+            end: [0, 7]
+          })
+        })
+    })
+
+    it('convert leading and trailing spaces into &nbsp;s', function () {
+      return utils
+        .init('<p><br></p>', {
+          start: [0, 0]
+        })
+        .paste('text/plain', ' One ')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: '&nbsp;One&nbsp;'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 5],
+            end: [0, 5]
+          })
+        })
+    })
+
+    it('convert a trailing double newline into a new paragraph', function () {
+      return utils
+        .init('<p>AC</p>', {
+          start: [0, 1]
+        })
+        .paste('text/plain', 'B\n\n')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'AB'
+            }, {
+              name: 'p',
+              html: 'C'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [1, 0],
+            end: [1, 0]
+          })
+        })
+    })
+
+    /*it('', function () {
+      return utils
+        .init('', {
+          start: []
+        })
+        .paste('text/plain', '')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: '',
+              html: ''
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [],
+            end: []
+          })
+        })
+    })*/
+  })
+
+  describe('html should', function () {
+    beforeEach(function () {
+      return browser.get(utils.url())
+    })
+
+    it('keep the type of the paragraph being pasted into', function () {
+      return utils
+        .init('<p>One</p>', {
+          start: [0, 3]
+        })
+        .paste('text/html', '<meta charset="UTF-8"><h2>Two</h2>')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'OneTwo'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 6],
+            end: [0, 6]
+          })
+        })
+    })
+
+    it('not preserve the type of an empty paragraph', function () {
+      return utils
+        .init('<p><br></p>', {
+          start: [0, 0]
+        })
+        .paste('text/html', '<meta charset="UTF-8"><pre>One</pre>')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'pre',
+              html: 'One'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 3],
+            end: [0, 3]
+          })
+        })
+    })
+
+    it('respect new paragraphs', function () {
+      return utils
+        .init('<p>OneFour</p>', {
+          start: [0, 3]
+        })
+        .paste('text/html', '<meta charset="UTF-8"><p>Two</p><p>Three</p>')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'OneTwo'
+            }, {
+              name: 'p',
+              html: 'ThreeFour'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [1, 5],
+            end: [1, 5]
+          })
+        })
+    })
+
+    it('override the end type of the paragraph being pasted into', function () {
+      return utils
+        .init('<p>AD</p>', {
+          start: [0, 1]
+        })
+        .paste('text/html', '<meta charset="UTF-8"><p>B</p><h2>C</h2>')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'AB'
+            }, {
+              name: 'h2',
+              html: 'CD'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [1, 1],
+            end: [1, 1]
+          })
+        })
+    })
+
+    it('remove <script>s and <style>s', function () {
+      return utils
+        .init('<p><br></p>', {
+          start: [0, 0]
+        })
+        .paste(
+          'text/html',
+          '<meta charset="UTF-8">' +
+          '<script>alert(1)</script>' +
+          '<style>* { border: 2px solid lime }</style>' +
+          '<p>One</p>'
+        )
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'One'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 3],
+            end: [0, 3]
+          })
+        })
+    })
+
+    it('handle pasting of whole documents', function () {
+      return utils
+        .init('<p><br></p>', {
+          start: [0, 0]
+        })
+        .paste(
+          'text/html',
+          '<!DOCTYPE html>' +
+          '<html lang="en">' +
+          '<head>' +
+            '<meta charset="UTF-8">' +
+            '<title>Things</title>' +
+          '</head>' +
+          '<body>' +
+            '<h2>Words</h2>' +
+            '<p>Stuff <i>and</i> things</p>' +
+          '</body>' +
+          '</html>'
+        )
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'h2',
+              html: 'Words'
+            }, {
+              name: 'p',
+              html: 'Stuff <em>and</em> things'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [1, 16],
+            end: [1, 16]
+          })
+        })
+    })
+
+    it('remove selected section breaks', function () {
+      return utils
+        .init('<section><p>AB</p></section><section><p>CD</p></section>', {
+          start: [0, 1],
+          end: [1, 1]
+        })
+        .paste('text/html', '<meta charset="UTF-8"><p>BC</p>')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'ABCD'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [0, 3],
+            end: [0, 3]
+          })
+        })
+    })
+
+    it('remove selected paragraphs', function () {
+      return utils
+        .init('<p>One</p><p>Two</p><p>Three</p><p>Four</p>', {
+          start: [0, 1],
+          end: [3, 2]
+        })
+        .paste('text/html', '<meta charset="UTF-8"><p>ne</p><p>Fo</p>')
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'One'
+            }, {
+              name: 'p',
+              html: 'Four'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [1, 2],
+            end: [1, 2]
+          })
+        })
+    })
+
+    // This is not currently implemented. It should probably be configurable
+    // and part of its own module.
+    it.skip('remove javascript links and event handlers', function () {
+      return utils
+        .init('<p><br></p>', {
+          start: [0, 0]
+        })
+        .paste(
+          'text/html',
+          '<meta charset="UTF-8">' +
+          '<p><a href="javascript:alert(1)">Click me</a></p>' +
+          '<p><em onclick="alert(1)">Or me</em></p>'
+        )
+        .result(function (tree, sel) {
+          expect(tree).to.resemble([{
+            name: 'section',
+            children: [{
+              name: 'hr'
+            }, {
+              name: 'p',
+              html: 'Click me'
+            }, {
+              name: 'p',
+              html: 'Or me'
+            }]
+          }])
+
+          expect(sel).to.deep.equal({
+            start: [1, 5],
+            end: [1, 5]
+          })
+        })
+    })
+  })
+})

--- a/test/functional/utils.js
+++ b/test/functional/utils.js
@@ -227,6 +227,27 @@ exports.cut = function (cb) {
   return exports
 }
 
+exports.paste = function (mime, data) {
+  browser.executeScript(function (mime, data) {
+    var obj = { clipboardData: {} }
+
+    // There doesn’t seem to be a good way to mimick the paste event, either.
+    obj.preventDefault = function () {}
+    obj.currentTarget = obj.target = window.editor.elem
+    obj.clipboardData.types = [mime]
+    obj.clipboardData.getData = function (type) {
+      if (type === mime) return data
+
+      return ''
+    }
+
+    window.editor.emit('paste', obj)
+
+  }, mime, data)
+
+  return exports
+}
+
 exports.url = function () {
   var address = httpServer.address(),
       url = 'http://'


### PR DESCRIPTION
Partially addresses #54. Things still to do:

- [ ] Currently, `<div style="font-weight: bold">` gets removed in favour of its children, but the bold styling isn’t preserved.
- [ ] `javascript:` links are not removed. This should maybe be done as a separate module, though.